### PR TITLE
[Feature] update current location attribute with typing control status

### DIFF
--- a/VEditorKit/Classes/VEditorTextStorage.swift
+++ b/VEditorKit/Classes/VEditorTextStorage.swift
@@ -108,20 +108,11 @@ extension VEditorTextStorage {
         self.replaceAttributesIfNeeds(textNode)
     }
     
-    public func updateCurrentLocationAttributesIfNeeds(_ textNode: VEditorTextNode) {
-        
-        self.prevCursorLocation = textNode.selectedRange.location
-    }
-    
     public func replaceAttributesIfNeeds(_ textNode: VEditorTextNode) {
         guard textNode.selectedRange.length > 1 else { return }
         self.status = .paste
         self.setAttributes(self.currentTypingAttribute,
                            range: textNode.selectedRange)
-    }
-    
-    private func isFlyToTargetLocationWithoutTyping(_ textNode: VEditorTextNode) -> Bool {
-        return abs(textNode.selectedRange.location - self.prevCursorLocation) > 1
     }
     
     public func paragraphStyleRange(_ range: NSRange) -> NSRange {


### PR DESCRIPTION
## Why need this change?: 
- 커서의 위치에 따라서 Typing Control의 Status와 UITextview의 TypingAttribute가 업데이트 되어야합니다.

## Change made & impact:
- support internal observeActiveTextNode and current location checker logic
- separate update current attribute logic from didTapTypingControl

## Test Scope:
- Not Yet

## Vertified snapshots (optional)
