### PR TITLE
Editor follow caret offset on scroll area

### DIFF
--- a/VEditorKit/Classes/VEditorNode.swift
+++ b/VEditorKit/Classes/VEditorNode.swift
@@ -168,6 +168,11 @@ extension VEditorNode {
                                            activeXMLs: activeXMLs,
                                            isBlockStyle: false)
             }).disposed(by: activeTextDisposeBag)
+        
+        activeTextNode?.rx.caretRect
+            .subscribe(onNext: { [weak self] rect in
+                self?.scrollToCursor(rect)
+            }).disposed(by: activeTextDisposeBag)
     }
     
     internal enum VEditorAttributeControlScope {
@@ -284,6 +289,14 @@ extension VEditorNode {
         }
         self.activeTextNode = textNode
         return textNode
+    }
+    
+    private func scrollToCursor(_ caretRect: CGRect) {
+        let visibleRect =
+            self.tableNode.view.convert(caretRect,
+                                        from: self.activeTextNode?.view)
+        (self.tableNode.view as UIScrollView)
+            .scrollRectToVisible(visibleRect, animated: false)
     }
 }
 

--- a/VEditorKit/Classes/VEditorTextNode.swift
+++ b/VEditorKit/Classes/VEditorTextNode.swift
@@ -15,7 +15,13 @@ extension Reactive where Base: VEditorTextNode {
     
     internal var currentLocationXMLTags: Observable<[String]> {
         return base.currentLocationXMLTagsRelay
-            .throttle(0.5, scheduler: MainScheduler.instance)
+            .throttle(0.1, scheduler: MainScheduler.instance)
+    }
+    
+    internal var caretRect: Observable<CGRect> {
+        return base.caretRectRelay
+            .distinctUntilChanged()
+            .throttle(0.1, scheduler: MainScheduler.instance)
     }
 }
 
@@ -36,6 +42,7 @@ public class VEditorTextNode: ASEditableTextNode, ASEditableTextNodeDelegate {
     
     private let rule: VEditorRule
     internal let currentLocationXMLTagsRelay = PublishRelay<[String]>()
+    internal let caretRectRelay = PublishRelay<CGRect>()
     
     public required init(_ rule: VEditorRule,
                          isEdit: Bool,
@@ -90,6 +97,12 @@ public class VEditorTextNode: ASEditableTextNode, ASEditableTextNodeDelegate {
                 return
             }
             self.currentLocationXMLTagsRelay.accept(xmlTags)
+        } else {
+            guard let textPostion: UITextPosition = editableTextNode.textView.selectedTextRange?.end else {
+                return
+            }
+            let caretRect: CGRect = editableTextNode.textView.caretRect(for: textPostion)
+            self.caretRectRelay.accept(caretRect)
         }
     }
     


### PR DESCRIPTION
## Why need this change?: 
- Typing 함에 따라서 caret이 사용자 스크린상 벗어났을 때 자동으로 커서로 스크롤해서 위치를 보정해준다.

## Change made & impact:
- scrollToCursor(_ caretRect: method

## Test Scope:
- Not yet


## Vertified snapshots (optional)
