### PR TITLE
Fix keyboard height bug: replace keyboardFrame begin to end userInfoKey

### DIFF
--- a/Example/VEditorKit/EditorRule.swift
+++ b/Example/VEditorKit/EditorRule.swift
@@ -149,7 +149,6 @@ struct EditorRule: VEditorRule {
     func activeTypingXMLs(_ inactiveXML: String) -> [String]? {
         return nil
     }
-    
 }
 
 class VImageContent: VEdiorMediaContent {

--- a/VEditorKit/Classes/VEditorNode.swift
+++ b/VEditorKit/Classes/VEditorNode.swift
@@ -476,7 +476,7 @@ extension VEditorNode {
     }
     
     @objc func keyboardWillShow(notification: Notification) {
-        guard let keyboardSize = (notification.userInfo?[UIResponder.keyboardFrameBeginUserInfoKey] as? NSValue)?.cgRectValue else {
+        guard let keyboardSize = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue else {
             return
         }
         self.keyboardHeight = keyboardSize.height


### PR DESCRIPTION
## Why need this change?: 
- In Chinese, Emoji Keyboard case, layoutSpec is applied by unexpected height.


## Change made & impact:
- keyboardFrameBeginUserInfoKey (x)
- keyboardFrameEndUserInfoKey (0)

