### PR TITLE
Fix selection range apply unexpected attribute apply bug

### DIFF
--- a/VEditorKit/Classes/VEditorTextNode.swift
+++ b/VEditorKit/Classes/VEditorTextNode.swift
@@ -93,6 +93,9 @@ public class VEditorTextNode: ASEditableTextNode, ASEditableTextNodeDelegate {
                 .attributes(at: max(toSelectedRange.location - 1, 0),
                             effectiveRange: nil)
             
+            // block current location attributes during drag-selection
+            guard fromSelectedRange.length < 1 else { return }
+            
             guard let xmlTags = attributes?[VEditorAttributeKey] as? [String] else {
                 return
             }


### PR DESCRIPTION
## Why need this change?: 
- During drag selection case on mixed attribute, unexpected attribute applied on selected range


## Change made & impact:
- block current location attribute picker on selection length is larger more than 1


## Test Scope:
- Nope


## Vertified snapshots (optional)
