### PR TITLE
[Feature] Regex Pattern Base Attributed Typing :) LOL

### DIFF
--- a/Example/VEditorKit/EditorNodeController.swift
+++ b/Example/VEditorKit/EditorNodeController.swift
@@ -62,6 +62,7 @@ extension EditorNodeController {
                                                    placeholderText: nil,
                                                    attributedText: text,
                                                    rule: self.node.editorRule)
+                cellNode.textNode.regexDelegate = self
                 
                 return cellNode
             case let imageNode as VImageContent:
@@ -216,5 +217,52 @@ extension EditorNodeController: UIImagePickerControllerDelegate, UINavigationCon
         }
         
         picker.dismiss(animated: true, completion: nil)
+    }
+}
+
+extension EditorNodeController: VEditorRegexApplierDelegate {
+    
+    enum EditorTextRegexPattern: String, CaseIterable {
+        
+        case userTag = "@(\\w*[0-9A-Za-z])"
+        case hashTag = "#(\\w*[0-9A-Za-zㄱ-ㅎ가-힣])"
+    }
+    
+    var allPattern: [String] {
+        return EditorTextRegexPattern.allCases.map({ $0.rawValue })
+    }
+    
+    func paragraphStyle(pattern: String) -> VEditorStyle? {
+        guard let scope = EditorTextRegexPattern.init(rawValue: pattern) else { return nil }
+        switch scope {
+        case .userTag:
+            return .init([.color(UIColor.init(red: 0.2, green: 0.8, blue: 0.2, alpha: 1.0))])
+        case .hashTag:
+            return .init([.color(UIColor.init(red: 0.2, green: 0.3, blue: 0.8, alpha: 1.0))])
+        }
+    }
+    
+    func handlePatternTouchEvent(_ pattern: String, value: Any) {
+        guard let scope = EditorTextRegexPattern.init(rawValue: pattern) else { return }
+        switch scope {
+        case .userTag:
+            guard let username = value as? String else { return }
+            let toast = UIAlertController(title: "You did tap username: \(username)",
+                message: nil,
+                preferredStyle: .alert)
+            toast.addAction(.init(title: "OK", style: .cancel, handler: nil))
+            self.present(toast, animated: true, completion: nil)
+        case .hashTag:
+            guard let tag = value as? String else { return }
+            let toast = UIAlertController(title: "You did tap hashTag: \(tag)",
+                message: nil,
+                preferredStyle: .alert)
+            toast.addAction(.init(title: "OK", style: .cancel, handler: nil))
+            self.present(toast, animated: true, completion: nil)
+        }
+    }
+    
+    func handlURLTouchEvent(_ url: URL) {
+        UIApplication.shared.openURL(url)
     }
 }

--- a/VEditorKit/Classes/Platform.swift
+++ b/VEditorKit/Classes/Platform.swift
@@ -25,6 +25,7 @@ public protocol VEdiorMediaContent: VEditorContent {
     func parseAttributeToXML() -> [String: String] // parseto xml attribute from media content
 }
 
+// MARK: - VEditorKit Editor Rule
 public protocol VEditorRule {
     var allXML: [String] { get }
     var defaultStyleXMLTag: String { get }
@@ -45,5 +46,24 @@ extension VEditorRule {
             fatalError("Please setup default:\(self.defaultStyleXMLTag) xml tag style")
         }
         return attr.attributes
+    }
+}
+
+// MARK: - VEditor Regex Text Atttribute Apply Delegate
+public protocol VEditorRegexApplierDelegate: class {
+    
+    var allPattern: [String] { get }
+    func paragraphStyle(pattern: String) -> VEditorStyle?
+    func handlePatternTouchEvent(_ pattern: String, value: Any)
+    func handlURLTouchEvent(_ url: URL)
+}
+
+extension VEditorRegexApplierDelegate {
+    
+    func regex(_ pattern: String) -> NSRegularExpression {
+        guard let reg = try? NSRegularExpression.init(pattern: pattern, options: []) else {
+            fatalError("VEditorKit Fatal Error: \(pattern) is invalid regex pattern")
+        }
+        return reg
     }
 }

--- a/VEditorKit/Classes/VEditorTextNode.swift
+++ b/VEditorKit/Classes/VEditorTextNode.swift
@@ -27,18 +27,17 @@ extension Reactive where Base: VEditorTextNode {
 
 public class VEditorTextNode: ASEditableTextNode, ASEditableTextNodeDelegate {
     
-    public var isEdit: Bool = true
-    
     public var textStorage: VEditorTextStorage? {
         return self.textView.textStorage as? VEditorTextStorage
     }
-    
     public var currentTypingAttribute: [NSAttributedString.Key: Any] = [:] {
         didSet {
             self.typingAttributes = currentTypingAttribute.typingAttribute()
             self.textStorage?.currentTypingAttribute = currentTypingAttribute
         }
     }
+    public var isEdit: Bool = true
+    public weak var regexDelegate: VEditorRegexApplierDelegate!
     
     private let rule: VEditorRule
     internal let currentLocationXMLTagsRelay = PublishRelay<[String]>()
@@ -97,6 +96,8 @@ public class VEditorTextNode: ASEditableTextNode, ASEditableTextNodeDelegate {
                 return
             }
             self.currentLocationXMLTagsRelay.accept(xmlTags)
+            // TBD: role needs
+            self.textStorage?.triggerTouchEventIfNeeds(self)
         } else {
             guard let textPostion: UITextPosition = editableTextNode.textView.selectedTextRange?.end else {
                 return

--- a/VEditorKit/Classes/VEditorTextStorage.swift
+++ b/VEditorKit/Classes/VEditorTextStorage.swift
@@ -101,6 +101,7 @@ extension VEditorTextStorage {
             let blockRange = self.paragraphStyleRange(textNode.selectedRange)
             self.status = .paste
             self.setAttributes(attribute, range: blockRange)
+            self.replaceAttributeWithRegexPattenIfNeeds(textNode, customRange: blockRange)
             textNode.setNeedsLayout()
         } else {
             self.setAttributes(attribute, range: textNode.selectedRange)
@@ -146,10 +147,10 @@ extension VEditorTextStorage {
 
 extension VEditorTextStorage {
 
-    private func replaceAttributeWithRegexPattenIfNeeds(_ textNode: VEditorTextNode) {
+    private func replaceAttributeWithRegexPattenIfNeeds(_ textNode: VEditorTextNode, customRange: NSRange? = nil) {
         guard let regexDelegate = textNode.regexDelegate else { return }
         let regexs = regexDelegate.allPattern.map({ regexDelegate.regex($0) })
-        let range: NSRange = .init(location: 0, length: self.internalAttributedString.length)
+        let range: NSRange = customRange ?? .init(location: 0, length: self.internalAttributedString.length)
         let text: String = self.internalAttributedString.string
         
         for regex in regexs {


### PR DESCRIPTION
## Why need this change?: 
- Regex Pattern Base Attributed Typing Avaliable such as @ UserTag # HashTag

## Change made & impact:
```swift
public protocol VEditorRegexApplierDelegate: class {

     var allPattern: [String] { get }
    func paragraphStyle(pattern: String) -> VEditorStyle?
    func handlePatternTouchEvent(_ pattern: String, value: Any)
    func handlURLTouchEvent(_ url: URL)
}
```
- allParttern: get all case regex pattern
- paragraphStyle: AttributedString Style base on regex pattern
- handlePatternTouchEvent: if textNode doesn't edit mode than trigger touch event
- handleURLTouchEvent: if textNode doesn't edit mode than trigger touch event


## Test Scope:
- Not yet

## Vertified snapshots (optional)
