### PR TITLE
Fix un-sync between textStorage size with editableNode viewFrame

### DIFF
--- a/VEditorKit/Classes/VEditorTextNode.swift
+++ b/VEditorKit/Classes/VEditorTextNode.swift
@@ -87,9 +87,19 @@ open class VEditorTextNode: ASEditableTextNode, ASEditableTextNodeDelegate {
             self.textView.linkTextAttributes = attrStyle.attributes
         }
         
-        self.supernode?.setNeedsLayout()
-        self.setNeedsLayout()
         self.textStorage?.replaceAttributeWithRegexPattenIfNeeds(self)
+    }
+    
+    override open func calculatedLayoutDidChange() {
+        super.calculatedLayoutDidChange()
+        guard let expectedHeight = self.textStorage?
+            .internalAttributedString.size().height,
+            expectedHeight > self.frame.height else {
+                // NOTE: pass setNeedsLayout
+                return
+        }
+        // NOTE: Unsyncronized frame height between storage with viewFrame
+        self.setNeedsLayout()
     }
     
     open func editableTextNodeShouldBeginEditing(_ editableTextNode: ASEditableTextNode) -> Bool {

--- a/VEditorKit/Classes/VEditorTextStorage.swift
+++ b/VEditorKit/Classes/VEditorTextStorage.swift
@@ -18,6 +18,11 @@ final public class VEditorTextStorage: NSTextStorage {
         case none
     }
     
+    internal struct Const {
+        static let urlPattern: String =
+        "((?:http|https)://)(?:www\\.)?[\\w\\d\\-_]+\\.\\w{2,3}(\\.\\w{2})?(/(?<=/)(?:[\\w\\d\\-./_]+)?)?"
+    }
+    
     internal var status: TypingStstus = .none
     internal var currentTypingAttribute: [NSAttributedString.Key: Any] = [:]
     internal var internalAttributedString: NSMutableAttributedString = .init()
@@ -154,8 +159,8 @@ extension VEditorTextStorage {
     }
     
     internal func automaticallyApplyLinkAttribute(_ textNode: VEditorTextNode) -> (URL, Int)? {
-        let pattern: String = "((?:http|https)://)(?:www\\.)?[\\w\\d\\-_]+\\.\\w{2,3}(\\.\\w{2})?(/(?<=/)(?:[\\w\\d\\-./_]+)?)?"
-        guard let regex = try? NSRegularExpression.init(pattern: pattern, options: []) else { return nil }
+        guard let regex = try? NSRegularExpression(pattern: Const.urlPattern,
+                                                   options: []) else { return nil }
         let blockRange = self.paragraphBlockRange(textNode.selectedRange)
         let text: String = self.internalAttributedString.string
         
@@ -203,7 +208,8 @@ extension VEditorTextStorage {
     public func replaceAttributeWithRegexPattenIfNeeds(_ textNode: VEditorTextNode, customRange: NSRange? = nil) {
         guard let regexDelegate = textNode.regexDelegate else { return }
         let regexs = regexDelegate.allPattern.map({ regexDelegate.regex($0) })
-        let range: NSRange = customRange ?? .init(location: 0, length: self.internalAttributedString.length)
+        let range: NSRange = customRange ?? .init(location: 0,
+                                                  length: self.internalAttributedString.length)
         let text: String = self.internalAttributedString.string
         
         for regex in regexs {


### PR DESCRIPTION
## Why need this change?: 
- Sometimes textView frame render unexpected height

## Change made & impact:
- insert frame validate logic on calculatedLayoutDidChange method

