### PR TITLE
[Feature] flexible media content node

### DIFF
--- a/VEditorKit/Classes/VEditorDeleteMediaNode.swift
+++ b/VEditorKit/Classes/VEditorDeleteMediaNode.swift
@@ -12,32 +12,18 @@ import RxSwift
 
 open class VEditorDeleteMediaNode: ASControlNode {
     
-    open lazy var deleteButtonNode: ASControlNode = {
-        let node = ASControlNode()
-        node.cornerRadius = 5.0
-        node.backgroundColor = self.deleteColor
-        node.style.preferredSize = .init(width: 50.0, height: 50.0)
-        return node
-    }()
+    open let deleteButtonNode = ASButtonNode()
     
-    open lazy var closeIconNode: ASImageNode = {
-        let node = ASImageNode()
-        node.isUserInteractionEnabled = false
-        node.backgroundColor = .white
-        node.style.preferredSize = .init(width: 30.0, height: 10.0)
-        node.cornerRadius = 5.0
-        return node
-    }()
-    
-    open let deleteColor: UIColor
-    open let deleteIconImage: UIImage?
-    
-    public init(_ color: UIColor, deleteIconImage: UIImage?) {
-        self.deleteColor = color
-        self.deleteIconImage = deleteIconImage
+    public init(_ color: UIColor = .red,
+                borderWidth: CGFloat = 5.0, // default is 5.0pt
+                iconImage: UIImage? = nil,
+                buttonSize: CGSize = .init(width: 50.0, height: 50.0)) {
         super.init()
-        self.borderWidth = 5.0
-        self.borderColor = deleteColor.cgColor
+        self.deleteButtonNode.style.preferredSize = buttonSize
+        self.deleteButtonNode.backgroundColor = color
+        self.deleteButtonNode.setImage(iconImage, for: .normal)
+        self.borderWidth = borderWidth
+        self.borderColor = color.cgColor
         self.automaticallyManagesSubnodes = true
         self.isHidden = true
     }
@@ -46,13 +32,6 @@ open class VEditorDeleteMediaNode: ASControlNode {
         return ASRelativeLayoutSpec(horizontalPosition: .end,
                                     verticalPosition: .start,
                                     sizingOption: [],
-                                    child: deleteButtonLayoutSpec())
-    }
-    
-    open func deleteButtonLayoutSpec() -> ASLayoutSpec {
-        let centerLayout = ASCenterLayoutSpec(centeringOptions: .XY,
-                                              sizingOptions: [],
-                                              child: closeIconNode)
-        return ASOverlayLayoutSpec(child: deleteButtonNode, overlay: centerLayout)
+                                    child: deleteButtonNode)
     }
 }

--- a/VEditorKit/Classes/VEditorDeleteMediaNode.swift
+++ b/VEditorKit/Classes/VEditorDeleteMediaNode.swift
@@ -39,6 +39,7 @@ open class VEditorDeleteMediaNode: ASControlNode {
         self.borderWidth = 5.0
         self.borderColor = deleteColor.cgColor
         self.automaticallyManagesSubnodes = true
+        self.isHidden = true
     }
     
     override open func layoutSpecThatFits(_ constrainedSize: ASSizeRange) -> ASLayoutSpec {

--- a/VEditorKit/Classes/VEditorImageNode.swift
+++ b/VEditorKit/Classes/VEditorImageNode.swift
@@ -21,10 +21,6 @@ open class VEditorImageNode: VEditorMediaNode<ASNetworkImageNode> {
         self.selectionStyle = .none
     }
     
-    public required init(node: ASNetworkImageNode, isEdit: Bool) {
-        fatalError("init(node:isEdit:) has not been implemented")
-    }
-    
     /**
      Set image url
      

--- a/VEditorKit/Classes/VEditorMediaNode.swift
+++ b/VEditorKit/Classes/VEditorMediaNode.swift
@@ -52,7 +52,7 @@ open class VEditorMediaNode<TargetNode: ASControlNode>: ASCellNode, VEditorMedia
     public var disposeBag: DisposeBag = DisposeBag()
     
     public init(node: TargetNode,
-                deleteNode: VEditorDeleteMediaNode = .init(.red, deleteIconImage: nil),
+                deleteNode: VEditorDeleteMediaNode = .init(),
                 isEdit: Bool) {
         self.node = node as! TargetNode
         self.isEdit = isEdit

--- a/VEditorKit/Classes/VEditorMediaNode.swift
+++ b/VEditorKit/Classes/VEditorMediaNode.swift
@@ -33,11 +33,7 @@ open class VEditorMediaNode<TargetNode: ASControlNode>: ASCellNode, VEditorMedia
         return node
     }()
     
-    open lazy var deleteControlNode: VEditorDeleteMediaNode = {
-        let node = VEditorDeleteMediaNode(.red, deleteIconImage: nil)
-        node.isHidden = true
-        return node
-    }()
+    open let deleteControlNode: VEditorDeleteMediaNode
     
     public let textInsertionRelay = PublishRelay<IndexPath>()
     public let didTapDeleteRelay = PublishRelay<IndexPath>()
@@ -55,9 +51,12 @@ open class VEditorMediaNode<TargetNode: ASControlNode>: ASCellNode, VEditorMedia
     
     public var disposeBag: DisposeBag = DisposeBag()
     
-    public required init(node: TargetNode, isEdit: Bool) {
-        self.node = node
+    public init(node: TargetNode,
+                deleteNode: VEditorDeleteMediaNode = .init(.red, deleteIconImage: nil),
+                isEdit: Bool) {
+        self.node = node as! TargetNode
         self.isEdit = isEdit
+        self.deleteControlNode = deleteNode
         super.init()
         self.automaticallyManagesSubnodes = true
         self.selectionStyle = .none
@@ -154,8 +153,21 @@ open class VEditorMediaNode<TargetNode: ASControlNode>: ASCellNode, VEditorMedia
         self.didTapDeleteRelay.accept(indexPath)
     }
     
+    /**
+     Make media content layoutSpec
+     
+     - important: If you needs attach subnodes or layout on media content
+     than you have to override this method
+     
+     - parameters: constrainedSize(ASSizeRange)
+     - returns: Media content layout spec (default is media ratioLayout)
+     */
+    open func mediaContentLayoutSpec(_ constrainedSize: ASSizeRange) -> ASLayoutSpec {
+        return ASRatioLayoutSpec(ratio: ratio, child: node)
+    }
+    
     override open func layoutSpecThatFits(_ constrainedSize: ASSizeRange) -> ASLayoutSpec {
-        let mediaRatioLayout = ASRatioLayoutSpec(ratio: ratio, child: node)
+        let mediaRatioLayout = self.mediaContentLayoutSpec(constrainedSize)
         
         let mediaContentLayout: ASLayoutElement
         

--- a/VEditorKit/Classes/VEditorOpenGraphNode.swift
+++ b/VEditorKit/Classes/VEditorOpenGraphNode.swift
@@ -55,8 +55,7 @@ open class VEditorOpenGraphNode: ASCellNode {
         return node
     }()
     
-    public lazy var deleteControlNode: VEditorDeleteMediaNode =
-        .init(.red, deleteIconImage: nil)
+    public lazy var deleteControlNode: VEditorDeleteMediaNode = .init()
     
     public var insets: UIEdgeInsets = .zero
     public var containerInsets: UIEdgeInsets = .zero

--- a/VEditorKit/Classes/VEditorVideoNode.swift
+++ b/VEditorKit/Classes/VEditorVideoNode.swift
@@ -30,10 +30,6 @@ open class VEditorVideoNode: VEditorMediaNode<ASVideoNode> {
         self.node.placeholderColor = .lightGray
     }
     
-    public required init(node: ASVideoNode, isEdit: Bool) {
-        fatalError("init(node:isEdit:) has not been implemented")
-    }
-    
     /**
      Set video preview image url
      


### PR DESCRIPTION
## Why need this change?: 
-  To make `VEditorMediaNode<TargetNode: ASControlNode>` subclass isn't good
-   EditorDeleteMediaNode isn't good expend
-  When TargetNode has layoutSpec than occur duplicate layoutSpec crash


## Change made & impact:
- `required init` convert to `init`
-  Optimize VEditorDeleteMediaNode properties
-  Support mediaContentLayoutSpec


## Test Scope:
- local unit test passed

## Vertified snapshots (optional)
