### PR TITLE
fix safe area insets on typing control area layoutSpec & ready for release hot fix v1.2.1

### DIFF
--- a/VEditorKit.podspec
+++ b/VEditorKit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
     
   s.name             = 'VEditorKit'
-  s.version          = '1.2.0'
+  s.version          = '1.2.1'
   s.summary          = 'Lightweight and Powerful Editor Kit'
   
   s.description      = 'Lightweight and Powerful Editor Kit built on Texture(AsyncDisplayKit)'


### PR DESCRIPTION
## Why need this change?: 
- ControlAreaLayoutSpec doesn't support safe area insets


## Change made & impact:
- support safe area insets for controlAreaLayout & separate layoutSpec
- keyboardHeight property access level turn to open from private

## Test Scope:
- None


## Vertified snapshots (optional)
