### PR TITLE
use NSDataDetector with NSTextCheckingResult.CheckingType.link

### DIFF
--- a/Example/Tests/VEditorTextNodeSpec.swift
+++ b/Example/Tests/VEditorTextNodeSpec.swift
@@ -44,8 +44,6 @@ class VEditorTextNodeSpec: QuickSpec {
                 it("should be success") {
                     expect(node.isEdit).to(beTrue())
                     expect(node.delegate).toNot(beNil())
-                    expect(node.linkRegexPattern == "((?:http|https)://)(?:www\\.)?[\\w\\d\\-_]+\\.\\w{2,3}(\\.\\w{2})?(/(?<=/)(?:[\\w\\d\\-./_]+)?)?")
-                        .to(beTrue())
                     expect(node.regexDelegate).toNot(beNil())
                     expect(node.automaticallyGenerateLinkPreview).to(beFalse())
                     expect(node.currentTypingAttribute.isEmpty).to(beFalse())

--- a/VEditorKit/Classes/VEditorTextNode.swift
+++ b/VEditorKit/Classes/VEditorTextNode.swift
@@ -55,17 +55,6 @@ open class VEditorTextNode: ASEditableTextNode, ASEditableTextNodeDelegate {
     open var automaticallyGenerateLinkPreview: Bool = false
     open let becomeActiveRelay = PublishRelay<Void>()
     
-    open var linkRegexPattern: String? {
-        // default: "((?:http|https)://)(?:www\\.)?[\\w\\d\\-_]+\\.\\w{2,3}(\\.\\w{2})?(/(?<=/)(?:[\\w\\d\\-./_]+)?)?"
-        get {
-            return self.textStorage?.urlPattern
-        }
-        set(pattern) {
-            guard let pattern = pattern else { return }
-            self.textStorage?.urlPattern = pattern
-        }
-    }
-    
     internal let rule: VEditorRule
     internal let currentLocationXMLTagsRelay = PublishRelay<[String]>()
     internal let caretRectRelay = PublishRelay<CGRect>()

--- a/VEditorKit/Classes/VEditorTextStorage.swift
+++ b/VEditorKit/Classes/VEditorTextStorage.swift
@@ -27,8 +27,6 @@ final public class VEditorTextStorage: NSTextStorage {
     
     internal var status: TypingStstus = .none
     internal var currentTypingAttribute: [NSAttributedString.Key: Any] = [:]
-    public var urlPattern: String =
-    "((?:http|https)://)(?:www\\.)?[\\w\\d\\-_]+\\.\\w{2,3}(\\.\\w{2})?(/(?<=/)(?:[\\w\\d\\-./_]+)?)?"
     
     override public var string: String {
         return self.internalString
@@ -250,8 +248,7 @@ extension VEditorTextStorage {
     }
     
     internal func automaticallyApplyLinkAttribute(_ textNode: VEditorTextNode) -> (URL, Int)? {
-        guard let regex = try? NSRegularExpression(pattern: self.urlPattern,
-                                                   options: []) else { return nil }
+        guard let regex = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue) else { return nil }
         let blockRange = self.paragraphBlockRange(textNode.selectedRange)
         let text: String = self.internalAttributedString.string
         


### PR DESCRIPTION
## Why need this change?: 
- unsafe link detector regex pattern


## Change made & impact:
- Use NSDataDetector with NSTextCheckingResult.CheckingType.link

## Test Scope:
- pass

## Vertified snapshots (optional)
