### PR TITLE
[Bug] User cannot remove last text node

### DIFF
--- a/VEditorKit/Classes/VEditorNode.swift
+++ b/VEditorKit/Classes/VEditorNode.swift
@@ -847,7 +847,9 @@ extension VEditorNode {
     
     private func deleteUnnecessaryEditableTextIfNeeds(with: UITableView.RowAnimation = .automatic) {
         guard let indexPath = self.activeTextIndexPath,
-            self.editorContents.count > 1 else { return }
+            self.editorContents.count > 1,
+            indexPath.row != self.editorContents.count - 1 else { return }
+        
         self.resignActiveTextNode()
         self.editorContents.remove(at: indexPath.row)
         self.tableNode.deleteRows(at: [indexPath], with: with)


### PR DESCRIPTION
## Why need this change?: 
- In one media & last text area case, If user remove last text area than no more typing new text.


## Change made & impact:
- deleteUnnecessaryEditableTextIfNeeds:, blocking remove last text node 


## Test Scope:
- private method 


## Vertified snapshots (optional)
