### PR TITLE
VEditorKit: Define default caret rect using with style.minHeight

### DIFF
--- a/Example/Tests/VEditorTextNodeSpec.swift
+++ b/Example/Tests/VEditorTextNodeSpec.swift
@@ -55,6 +55,11 @@ class VEditorTextNodeSpec: QuickSpec {
                     expect(node.editableTextNodeShouldBeginEditing(node)).to(beFalse())
                     node.isEdit = true
                 }
+                
+                it("should be setup minimum text container line height") {
+                    expect(node.minimumTextContainerTextLineHeight())
+                        .to(equal(((rule.defaultAttribute()[.paragraphStyle] as? NSParagraphStyle)?.minimumLineHeight ?? -1.0)))
+                }
             }
             
             context("forceFetchCurrentLocationAttribute: test") {

--- a/VEditorKit/Classes/VEditorTextNode.swift
+++ b/VEditorKit/Classes/VEditorTextNode.swift
@@ -81,6 +81,7 @@ open class VEditorTextNode: ASEditableTextNode, ASEditableTextNodeDelegate {
         super.init(textKitComponents: textKitComponents,
                    placeholderTextKitComponents: placeholderTextKit)
         super.delegate = self
+        self.style.minHeight = .init(unit: .points, value: self.minimumTextContainerTextLineHeight())
         self.scrollEnabled = false
         self.attributedText = attributedText
     }
@@ -94,6 +95,13 @@ open class VEditorTextNode: ASEditableTextNode, ASEditableTextNodeDelegate {
         }
         
         self.textStorage?.replaceAttributeWithRegexPattenIfNeeds(self)
+    }
+    
+    open func minimumTextContainerTextLineHeight() -> CGFloat {
+        guard let paragraph = rule.defaultAttribute()[.paragraphStyle] as? NSParagraphStyle else {
+            return 0.0
+        }
+        return paragraph.minimumLineHeight
     }
     
     open func editableTextNodeShouldBeginEditing(_ editableTextNode: ASEditableTextNode) -> Bool {


### PR DESCRIPTION
## Why need this change?: 
- Empty Text View Caret size is too small & unmatched with default typing paragraph lineheight

## Change made & impact:
- Setup style minimum height 


## Test Scope:
- minimumTextContainerTextLineHeight() should be return expected height

## Vertified snapshots (optional)
