### PR TITLE
[Bug] Reset selectedRange length before resign first responder

### DIFF
--- a/VEditorKit/Classes/VEditorTextNode.swift
+++ b/VEditorKit/Classes/VEditorTextNode.swift
@@ -104,6 +104,10 @@ open class VEditorTextNode: ASEditableTextNode, ASEditableTextNodeDelegate {
         self.becomeActiveRelay.accept(())
     }
     
+    open func editableTextNodeDidFinishEditing(_ editableTextNode: ASEditableTextNode) {
+        self.selectedRange = NSRange(location: self.selectedRange.location, length: 0)
+    }
+    
     open func editableTextNode(_ editableTextNode: ASEditableTextNode,
                                shouldChangeTextIn range: NSRange,
                                replacementText text: String) -> Bool {


### PR DESCRIPTION
## Why need this change?: 
- Reset selectedRange length with sustain location before resign first responder about activted textView


## Change made & impact:
- selectedRange length will be zero at editableTextNodeDidFinishEditing: method

## Test Scope:
- pass

## Vertified snapshots (optional)
