### PR TITLE
Migration Texture2.8

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -3,7 +3,7 @@ inhibit_all_warnings!
 
 target 'VEditorKit_Example' do
   pod 'VEditorKit', :path => '../'
-  pod 'Texture', '2.7'
+  pod 'Texture', '2.8'
   pod 'RxSwift'
   pod 'RxCocoa'
 

--- a/Example/VEditorKit.xcodeproj/project.pbxproj
+++ b/Example/VEditorKit.xcodeproj/project.pbxproj
@@ -702,6 +702,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
+					"AS_USE_VIDEO=1",
 				);
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
@@ -721,6 +722,11 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
+				);
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"COCOAPODS=1",
+					"AS_USE_VIDEO=1",
 				);
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";

--- a/VEditorKit.podspec
+++ b/VEditorKit.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
     
   s.name             = 'VEditorKit'
-  s.version          = '1.3.8'
+  s.version          = '1.4.0'
   s.summary          = 'Lightweight and Powerful Editor Kit'
   
   s.description      = 'Lightweight and Powerful Editor Kit built on Texture(AsyncDisplayKit)'
@@ -12,9 +12,10 @@ Pod::Spec.new do |s|
   
   s.ios.deployment_target = '9.0'
   s.requires_arc = true
-
+  s.xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) AS_USE_VIDEO=1' }
+  
   s.source_files = 'VEditorKit/**/*'
-  s.dependency 'Texture', '~> 2.7'
+  s.dependency 'Texture', '2.8'
   s.dependency 'BonMot'
   s.dependency 'RxSwift'
   s.dependency 'RxCocoa'


### PR DESCRIPTION
## Why need this change?: 
- Texture 2.8 migration


## Change made & impact:
- AS_USE_VIDEO flag added in Texture 2.8
https://github.com/TextureGroup/Texture/pull/1240 
Example:
`spec.xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => '$(inherited) AS_USE_VIDEO=1' }`

## Test Scope:
- sustain


## Vertified snapshots (optional)
