### PR TITLE
Modify the point of deletion of text node

### DIFF
--- a/VEditorKit/Classes/VEditorTextNode.swift
+++ b/VEditorKit/Classes/VEditorTextNode.swift
@@ -119,8 +119,11 @@ open class VEditorTextNode: ASEditableTextNode, ASEditableTextNodeDelegate {
     open func editableTextNode(_ editableTextNode: ASEditableTextNode,
                                shouldChangeTextIn range: NSRange,
                                replacementText text: String) -> Bool {
-        
-        if (text == "\n" || text == " "),
+        if text.isEmpty {
+            guard self.isDisplayingPlaceholder() else { return true }
+            self.textEmptiedRelay.accept(())
+            return true
+        } else if (text == "\n" || text == " "),
             let context = self.textStorage?
                 .automaticallyApplyLinkAttribute(self) {
             guard self.automaticallyGenerateLinkPreview else { return true }
@@ -172,9 +175,6 @@ open class VEditorTextNode: ASEditableTextNode, ASEditableTextNodeDelegate {
     
     open func editableTextNodeDidUpdateText(_ editableTextNode: ASEditableTextNode) {
         self.textStorage?.didUpdateText(self)
-        
-        guard self.isDisplayingPlaceholder() else { return }
-        self.textEmptiedRelay.accept(())
     }
     
     open func updateCurrentTypingAttribute(_ attribute: VEditorStyleAttribute,


### PR DESCRIPTION
## Why need this change?: 
- Modify the point of deletion of text node
AS-IS : some text -> empty
TO-BE: empty -> back pressed

## Change made & impact:
- Move textEmptiedRelay from `editableTextNodeDidUpdateText` to `shouldChangeTextIn`

## Test Scope:
- x

## Vertified snapshots (optional)
