### PR TITLE
improve unused _ASTableCellView manage safe and performance

### DIFF
--- a/Example/VEditorKit/Controllers/EditorNodeController.swift
+++ b/Example/VEditorKit/Controllers/EditorNodeController.swift
@@ -221,25 +221,17 @@ extension EditorNodeController {
     }
     
     @objc func pushXMLViewer() {
-        self.node.synchronizeFetchContents { [weak self] () in
-            
-            guard let output = self?.node.buildXML(packageTag: "content") else {
-                return
-            }
-            let vc = XMLViewController.init(output)
-            self?.navigationController?.pushViewController(vc, animated: true)
-        }
+        self.node.synchronizeFetchContents()
+        guard let output = self.node.buildXML(packageTag: "content") else { return }
+        let vc = XMLViewController.init(output)
+        self.navigationController?.pushViewController(vc, animated: true)
     }
     
     @objc func previewViewer() {
-        self.node.synchronizeFetchContents { [weak self] () in
-            guard let xmlString = self?.node
-                .buildXML(packageTag: "content") else {
-                    return
-            }
-            let vc = EditorNodeController(isEditMode: false, xmlString: xmlString)
-            self?.navigationController?.pushViewController(vc, animated: true)
-        }
+        self.node.synchronizeFetchContents()
+        let xmlString = self.node.buildXML(packageTag: "content")
+        let vc = EditorNodeController(isEditMode: false, xmlString: xmlString)
+        self.navigationController?.pushViewController(vc, animated: true)
     }
 }
 

--- a/VEditorKit/Classes/VEditorNode.swift
+++ b/VEditorKit/Classes/VEditorNode.swift
@@ -239,16 +239,11 @@ open class VEditorNode: ASDisplayNode, ASTableDelegate, ASTableDataSource {
         // Bug Issue:  https://github.com/TextureGroup/Texture/issues/1407
         let currentActiveTextASCellView = self.activeTextContainCellNode?.view.superview?.superview
         
-        let invalidSubViews = self.tableNode.view.subviews.filter({ subView -> Bool in
-            
-            for visibleCell in self.tableNode.view.visibleCells {
-                if subView.frame == visibleCell.frame {
-                    return false
-                }
-            }
-            
-            return true
-        }).filter({ $0 != currentActiveTextASCellView })
+        let invalidSubViews = self.tableNode.view.subviews
+            .filter({ subView -> Bool in
+                return !self.tableNode.view.visibleCells.map({ $0.frame }).contains(subView.frame)
+            })
+            .filter({ $0 != currentActiveTextASCellView })
         
         guard !invalidSubViews.filter({ $0 != currentActiveTextASCellView }).isEmpty else { return }
         

--- a/VEditorKit/Classes/VEditorNode.swift
+++ b/VEditorKit/Classes/VEditorNode.swift
@@ -93,6 +93,7 @@ open class VEditorNode: ASDisplayNode, ASTableDelegate, ASTableDataSource {
     
     private var typingControls: [VEditorTypingControlNode] = []
     private var activeTextDisposeBag = DisposeBag()
+    private let synchronizeContentLock = NSLock()
     
     public init(editorRule: VEditorRule,
                 controlAreaNode: ASDisplayNode?) {
@@ -531,8 +532,10 @@ open class VEditorNode: ASDisplayNode, ASTableDelegate, ASTableDataSource {
      - section: editor target section
      - complate: complate syncronize callback
      */
-    open func synchronizeFetchContents(in section: Int = 0,
-                                       _ complate: @escaping () -> Void) {
+    open func synchronizeFetchContents(in section: Int = 0) {
+        defer { self.synchronizeContentLock.unlock() }
+        self.synchronizeContentLock.lock()
+        
         let numberOfSection = self.tableNode.numberOfSections
         guard section >= 0, section < numberOfSection else {
             fatalError("Invalid access section \(section) in \(numberOfSection)")
@@ -552,8 +555,6 @@ open class VEditorNode: ASDisplayNode, ASTableDelegate, ASTableDataSource {
                     .attributedString() else { return }
             self.editorContents[index] = currentAttributedText
         }
-        
-        complate()
     }
     
     /**


### PR DESCRIPTION
## Why need this change?: 
- unsafe to save draft (sync-contents)
- Sometimes unexpected _ASTableCellView attached onto view hierarchy after remove content


## Change made & impact:
- remove synchronizeFetchContent completion callback and support stack frame lock
- activeTextContainCellNode should be weak referrence
- create a removeUnusedInternalASTableCellViewIfNeeds method, check unused InternalASTableCellView(_ASTableCellView) during scroll.


## Test Scope:
- sustain.


## Vertified snapshots (optional)
